### PR TITLE
NODE-85: Fix cleanup_create order

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1008,13 +1008,14 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 					.record_deposit(out.len())
 				{
 					Ok(()) => {
-						let exit_result = self.exit_substate(StackExitKind::Succeeded);
-
 						if let Err(e) =
 							self.record_external_operation(crate::ExternalOperation::Write)
 						{
+							self.state.metadata_mut().gasometer.fail();
+							let _ = self.exit_substate(StackExitKind::Failed);
 							return (e.into(), None, Vec::new());
 						}
+						let exit_result = self.exit_substate(StackExitKind::Succeeded);
 						self.state.set_code(address, out);
 						if let Err(e) = exit_result {
 							return (e.into(), None, Vec::new());


### PR DESCRIPTION
- cve: https://www.opencve.io/cve/CVE-2024-21629
- patch: https://github.com/rust-ethereum/evm/pull/264/files

### Changes
- 가장 최신 버전의 bifrost-frontier에서 사용중이던 evm 버전 (commit: b7b82c7e1fc57b7449d6dfa6826600de37cc1e65) 기준에서 패치 커밋 cherry-pick